### PR TITLE
Return single Polygon if type is Polygon in decodePolygon

### DIFF
--- a/esri2geo.js
+++ b/esri2geo.js
@@ -84,7 +84,7 @@ function toGeoJSON(data,cb){
 		}else{
 			type="MultiPolygon";
 		}
-		return {"type":type,"coordinates":coords};
+		return {"type":type,"coordinates":(coords.length===1)?coords[0]:coords};
 	}
 	/*determine if polygon ring coordinates are clockwise. clockwise signifies outer ring, counter-clockwise an inner ring
 	or hole. this logic was found at http://stackoverflow.com/questions/1165647/how-to-determine-if-a-list-of-polygon-


### PR DESCRIPTION
The decodePolygon function was always returning an array of Polygons. This
would work if the type was MultiPolygon. But if there was a single Polygon
with holes, it wouldn't work because the type was Polygon but it was nested
too deep within a MultiPolygon structrue.

I changed it such that when coords.length === 1 (type is Polygon) then
return coords[0]. Otherwise it returns coords.

http://www.geojson.org/geojson-spec.html#id4
