### PR TITLE
Fix property assignment where value is zero

### DIFF
--- a/esri2geo.js
+++ b/esri2geo.js
@@ -113,7 +113,7 @@ var esri2geo = {};
   function prop(a){
     var p = {};
     for(var k in a){
-      if(a.hasOwnProperty(k)){
+      if(!(a[k] === undefined)){
         p[k]=a[k];  
       }
     }

--- a/esri2geo.js
+++ b/esri2geo.js
@@ -113,7 +113,7 @@ var esri2geo = {};
   function prop(a){
     var p = {};
     for(var k in a){
-      if(a[k]){
+      if(a.hasOwnProperty(k)){
         p[k]=a[k];  
       }
     }


### PR DESCRIPTION
When an attribute value is `0` (or `false`) the conditional in the prop method returns false and skips the assignment to the p object. Using `hasOwnProperty` avoids this issue.