### PR TITLE
Update dependency request to cope with webpack warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,19 +11,14 @@
   "bugs": {
     "url": "https://github.com/calvinmetcalf/esri2geo/issues"
   },
-  "repository":
-    {
-      "type": "git",
-      "url": "https://github.com/calvinmetcalf/esri2geo.git"
-    },
-  "main": "esri2geo.js",
-  "license": "MIT",
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "git://github.com/calvinmetcalf/esri2geo.git"
   },
+  "main": "esri2geo.js",
+  "license": "MIT",
+  "devDependencies": {},
   "dependencies": {
-    "request": "~2.27.0"
+    "request": "^2.79.0"
   }
 }


### PR DESCRIPTION
I know you are not a fan of webpack, but using this library in a webpack setting I got the error:

```Critical dependency: the request of a dependency is an expression```

After some digging it turns out that this is due to something done by a dependency of request, hoek, where they basically do

```request(path + '/' name)```

(or something to that effect)

Someone on stackoverflow suggested updating request: https://stackoverflow.com/a/42924147/1328635

And this works fine, as the version of hoek that this request-version depends on does not use this expression require-syntax, which according to webpack devs, "should *not* be ignored" (https://github.com/webpack/webpack/issues/196#issuecomment-71917456)

Hopefully you'll merge this and make a webpack user happy?
